### PR TITLE
Fix bugs in setup scripts

### DIFF
--- a/00_Setup/scripts/installer.sh
+++ b/00_Setup/scripts/installer.sh
@@ -170,8 +170,6 @@ rm -rf fzf.tar.gz
 
 # bat
 download "https://github.com/sharkdp/bat/releases/download/v${bat_version}/bat-v${bat_version}-${arch}-unknown-linux-gnu.tar.gz" "bat.tar.gz"
-download "https://github.com/sharkdp/bat/releases/download/v0.25.0/bat-v0.25.0-x86_64-unknown-linux-gnu.tar.gz" "bat.tar.gz"
-download "https://github.com/sharkdp/bat/releases/download/v0.25.0/bat-v0.25.0-x86_64-unknown-linux-gnu.tar.gz" "bat.tar.gz"
 tar xfz bat.tar.gz
 chmod +x bat-v${bat_version}-${arch}-unknown-linux-gnu/bat
 chown root:root bat-v${bat_version}-${arch}-unknown-linux-gnu/bat

--- a/00_Setup/scripts/setup.sh
+++ b/00_Setup/scripts/setup.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-if [[ ! -d "~/.bashrc.d" ]]; then
+if [[ ! -d ~/.bashrc.d ]]; then
   mkdir -p ~/.bashrc.d
-  
+
   touch ~/.bashrc.d/dummy.bash
 
   echo 'for file in ~/.bashrc.d/*.bash; do source "$file"; done' >> ~/.bashrc


### PR DESCRIPTION
## Summary
- fix incorrect tilde expansion check in setup.sh
- clean up duplicate download commands in installer.sh

## Testing
- `make test` *(fails: No rule to make target)*
- `pytest` *(fails: command not found)*